### PR TITLE
Task 55 - Decrease neighbourhood size during high score iterations

### DIFF
--- a/src/neighborhood.jl
+++ b/src/neighborhood.jl
@@ -4,6 +4,8 @@ export Neighborhood, get_max_nbhd_size, n_split_nbhd
 
 using ..NurseSchedules:
     Schedule, Shifts, get_shifts, W, CHANGEABLE_SHIFTS, Mutation, MutationRecipe
+    
+using StatsBase: sample
 
 import Base: length, iterate, getindex, in
 
@@ -35,6 +37,18 @@ struct Neighborhood
     function Neighborhood(shifts::Shifts, frozen_shifts::Vector{Tuple{Int,Int}})
         allowed_mutations = filter(recipe -> !(recipe in frozen_shifts), get_nbhd(shifts))
         new(allowed_mutations, shifts)
+    end
+
+    function Neighborhood(shifts::Shifts, frozen_days::Vector{Int}, sample_size::Real)
+        allowed_mutations = filter(recipe -> !(recipe.day in frozen_days), get_nbhd(shifts))
+        size = max(floor(Int, (length(allowed_mutations) * sample_size)), 1)
+        new(sample(allowed_mutations, size, replace=false), shifts)
+    end
+
+    function Neighborhood(shifts::Shifts, frozen_shifts::Vector{Tuple{Int, Int}}, sample_size::Real)
+        allowed_mutations = filter(recipe -> !(recipe in frozen_shifts), get_nbhd(shifts))
+        size = max(floor(Int, length(allowed_mutations) * sample_size), 1)
+        new(sample(allowed_mutations, size, replace=false), shifts)
     end
 end
 

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -16,9 +16,9 @@ const EXTENDED_NBHD_LVL_1 = 10
 const WRKS_RANDOM_FACTOR = 0.2
 
 # Minimal score to decrease nbhd size
-const OPT_LVL_1_PEN = 100
+const NBHD_OPT_PEN = 200
 # Percentage of nhbd checked while penalty is higher than the threshold
-const OPT_LVL_1_SAMPLE = 0.2
+const NBHD_OPT_SAMPLE_SIZE = 0.2
 
 # basic local search
 const MAX_NO_IMPROVS = 20

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -15,5 +15,10 @@ const EXTENDED_NBHD_LVL_1 = 10
 
 const WRKS_RANDOM_FACTOR = 0.2
 
+# Minimal score to decrease nbhd size
+const OPT_LVL_1_PEN  = 100
+# Percentage of nhbd checked while penalty is higher than the threshold
+const OPT_LVL_1_SAMPLE = 0.2
+
 # basic local search
 const MAX_NO_IMPROVS = 20

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -16,7 +16,7 @@ const EXTENDED_NBHD_LVL_1 = 10
 const WRKS_RANDOM_FACTOR = 0.2
 
 # Minimal score to decrease nbhd size
-const OPT_LVL_1_PEN  = 100
+const OPT_LVL_1_PEN = 100
 # Percentage of nhbd checked while penalty is higher than the threshold
 const OPT_LVL_1_SAMPLE = 0.2
 

--- a/src/repair_schedule.jl
+++ b/src/repair_schedule.jl
@@ -57,9 +57,9 @@ function repair_schedule(schedule_data)
             workers_info,
             return_errors = true,
         )
-        act_frozen_shifts = eval_frozen_shifts(month_info, errors, no_improved_iters, workers, previous_best_iter_score > OPT_LVL_1_PEN)
-        nbhd = if previous_best_iter_score > OPT_LVL_1_PEN 
-            Neighborhood(best_iter_res.shifts, act_frozen_shifts, OPT_LVL_1_SAMPLE)
+        act_frozen_shifts = eval_frozen_shifts(month_info, errors, no_improved_iters, workers, !(previous_best_iter_score > NBHD_OPT_PEN))
+        nbhd = if previous_best_iter_score > NBHD_OPT_PEN 
+            Neighborhood(best_iter_res.shifts, act_frozen_shifts, NBHD_OPT_SAMPLE_SIZE)
         else
             Neighborhood(best_iter_res.shifts, act_frozen_shifts)
         end
@@ -152,7 +152,7 @@ function eval_frozen_shifts(
     errors::Vector,
     no_improved_iters::Int,
     workers,
-    only_const::Bool
+    return_iter_shifts::Bool
 )::Vector{Tuple{Int,Int}}
     num_days = length(month_info["children_number"])
     num_wrks = length(workers)
@@ -162,7 +162,7 @@ function eval_frozen_shifts(
         for (wrk, day_no) in month_info["frozen_shifts"]
     ]
 
-    if only_const
+    if !return_iter_shifts
         return always_frozen_shifts
     end
 


### PR DESCRIPTION
Jeśli wynik poprzedniej iteracji był wyższy od progu _OPT_LVL_1_PEN_, bierze tylko _OPT_LVL_1_SAMPLE_ procent sąsiedztwa.