### PR TITLE
TASK-149 Support different constraint priorities

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -1,8 +1,14 @@
 {
-    "penalties" : {
-        "LACKING_NURSE" : 40,
-        "LACKING_WORKER" : 30,
-        "NO_LONG_BREAK" : 20,
-        "DISALLOWED_SHIFT_SEQ" : 10
-    }
+    "penalties" : [
+        "LACKING_NURSE",
+        "LACKING_WORKER",
+        "NO_LONG_BREAK",
+        "DISALLOWED_SHIFT_SEQ"
+    ],
+    "weightMap" : [
+        40,
+        30,
+        20,
+        10
+    ]
 }

--- a/config/default.json
+++ b/config/default.json
@@ -1,11 +1,11 @@
 {
     "penalties" : [
-        "LACKING_NURSE",
-        "LACKING_WORKER",
-        "NO_LONG_BREAK",
-        "DISALLOWED_SHIFT_SEQ"
+        "AON",
+        "WND",
+        "LLB",
+        "DSS"
     ],
-    "weightMap" : [
+    "weight_map" : [
         40,
         30,
         20,

--- a/config/default.json
+++ b/config/default.json
@@ -1,0 +1,8 @@
+{
+    "penalties" : {
+        "LACKING_NURSE" : 40,
+        "LACKING_WORKER" : 30,
+        "NO_LONG_BREAK" : 20,
+        "DISALLOWED_SHIFT_SEQ" : 10
+    }
+}

--- a/schedules/schedule_2016_august_medium_with_priorities.json
+++ b/schedules/schedule_2016_august_medium_with_priorities.json
@@ -5,10 +5,10 @@
         "year": 2016
     },
     "penalty_priorities" : [
-        "LACKING_NURSE",
-        "DISALLOWED_SHIFT_SEQ",
-        "NO_LONG_BREAK",
-        "LACKING_WORKER"
+        "AON",
+        "LLB",
+        "DSS",
+        "WND"
     ],
     "month_info": {
         "frozen_shifts": [],

--- a/schedules/schedule_2016_august_medium_with_priorities.json
+++ b/schedules/schedule_2016_august_medium_with_priorities.json
@@ -1,0 +1,128 @@
+{
+    "schedule_info":{
+        "UUID": "",
+        "month_number": 8,
+        "year": 2016
+    },
+    "penalty_priorities" : [
+        "LACKING_NURSE",
+        "DISALLOWED_SHIFT_SEQ",
+        "NO_LONG_BREAK",
+        "LACKING_WORKER"
+    ],
+    "month_info": {
+        "frozen_shifts": [],
+        "extra_workers": [
+            4, 4, 4, 4, 4, 4, 4
+        ],
+        "children_number": [
+            24, 21, 21, 21, 21, 21, 21
+        ],
+        "holidays": [
+            7
+        ]
+    },
+    "employee_info": {
+        "time": {
+            "nurse_1":  1.0,
+            "nurse_2":  1.0,
+            "nurse_3":  1.0,
+            "nurse_4":  1.0,
+            "nurse_5":  0.5,
+            "nurse_6":  0.5,
+            "nurse_7":  0.5,
+            "nurse_8":  1.0,
+            "nurse_9":  1.0,
+            "babysitter_1": 1.0,
+            "babysitter_2": 0.5,
+            "babysitter_3": 0.5,
+            "babysitter_4": 1.0,
+            "babysitter_5": 1.0,
+            "babysitter_6": 1.0,
+            "babysitter_7": 0.5,
+            "babysitter_8": 1.0,
+            "babysitter_9": 1.0,
+            "babysitter_10": 0.5
+        },
+        "type": {
+            "nurse_1":  "NURSE",
+            "nurse_2":  "NURSE",
+            "nurse_3":  "NURSE",
+            "nurse_4":  "NURSE",
+            "nurse_5":  "NURSE",
+            "nurse_6":  "NURSE",
+            "nurse_7":  "NURSE",
+            "nurse_8":  "NURSE",
+            "nurse_9":  "NURSE",
+            "babysitter_1": "OTHER",
+            "babysitter_2": "OTHER",
+            "babysitter_3": "OTHER",
+            "babysitter_4": "OTHER",
+            "babysitter_5": "OTHER",
+            "babysitter_6": "OTHER",
+            "babysitter_7": "OTHER",
+            "babysitter_8": "OTHER",
+            "babysitter_9": "OTHER",
+            "babysitter_10": "OTHER"
+        }
+    },
+    "shifts": {
+        "nurse_1": [
+            "R", "R", "W", "W", "D", "DN", "W"
+        ],
+        "nurse_2": [
+            "N", "W", "N", "W", "W", "W", "DN"
+        ],
+        "nurse_3": [
+            "DN", "W", "DN", "N", "W", "DN", "N"
+        ],
+        "nurse_4": [
+            "N", "W", "D", "D", "N", "W", "D"
+        ],
+        "nurse_5": [
+            "W", "W", "W", "W", "W", "W", "W"
+        ],
+        "nurse_6": [
+            "U", "U", "U", "U", "U", "U", "U"
+        ],
+        "nurse_7": [
+            "U", "U", "U", "U", "U", "U", "U"
+        ],
+        "nurse_8": [
+            "D", "N", "W", "D", "R", "W", "D"
+        ],
+        "nurse_9": [
+            "W", "DN", "W", "W", "DN", "W", "W"
+        ],
+        "babysitter_1": [
+            "U", "U", "U", "U", "U", "U", "U"
+        ],
+        "babysitter_2": [
+            "L4", "L4", "L4", "L4", "L4", "L4", "L4"
+        ],
+        "babysitter_3": [
+            "U", "U", "U", "U", "U", "U", "U"
+        ],
+        "babysitter_4": [
+            "D", "N", "W", "D", "N", "W", "DN"
+        ],
+        "babysitter_5": [
+            "D", "P", "N", "N", "W", "W", "W"
+        ],
+        "babysitter_6": [
+            "W", "N", "N", "N", "N", "N", "W"
+        ],
+        "babysitter_7": [
+            "W", "D", "D", "W", "D", "DN", "W"
+        ],
+        "babysitter_8": [
+            "L4", "L4", "L4", "L4", "L4", "L4", "L4"
+        ],
+        "babysitter_9": [
+            "N", "W", "D", "N", "P", "W", "W"
+        ],
+        "babysitter_10": [
+            "W", "D", "W", "D", "W", "D", "W"
+        ]
+    }
+}

--- a/src/NurseScheduling.jl
+++ b/src/NurseScheduling.jl
@@ -3,6 +3,7 @@ module NurseSchedules
 export Schedule,
        Neighborhood,
        score,
+       get_penalties,
        get_shifts,
        get_max_nbhd_size,
        get_month_info,

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -57,6 +57,8 @@ const LONG_BREAK_SEQ = (([U, L4, W], [N, U, L4, W]), ([R, P, D], [U, L4, W]))
 const MAX_OVERTIME = 10 # scaled by the number of weeks
 const MAX_UNDERTIME = 0 # scaled by the number of weeks
 
+const CONFIG = JSON.parsefile("config/default.json")
+
 # weekly worktime
 const WORKTIME_BASE = 40
 

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -68,6 +68,13 @@ const SUNDAY_NO = 0
 
 const WORKTIME_DAILY = WORKTIME_BASE / NUM_WORKING_DAYS
 
+@se Constraints begin
+    PEN_LACKING_NURSE => "AON"
+    PEN_LACKING_WORKER => "WND"
+    PEN_NO_LONG_BREAK => "LLB"
+    PEN_DISALLOWED_SHIFT_SEQ => "DSS"
+end
+
 @se TimeOfDay begin
     MORNING => "MORNING"
     AFTERNOON => "AFTERNOON"

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -53,11 +53,6 @@ const DISALLOWED_SHIFTS_SEQS =
 # there has to be such a seq each week
 const LONG_BREAK_SEQ = (([U, L4, W], [N, U, L4, W]), ([R, P, D], [U, L4, W]))
 
-# penalties
-const PEN_LACKING_NURSE = 40
-const PEN_LACKING_WORKER = 30
-const PEN_NO_LONG_BREAK = 20
-const PEN_DISALLOWED_SHIFT_SEQ = 10
 # under and overtime pen is equal to hours from <0, MAX_OVERTIME>
 const MAX_OVERTIME = 10 # scaled by the number of weeks
 const MAX_UNDERTIME = 0 # scaled by the number of weeks

--- a/src/repair_schedule.jl
+++ b/src/repair_schedule.jl
@@ -18,11 +18,12 @@ function get_errors(schedule_data)
 
     nurse_schedule = Schedule(schedule_data)
 
+    schedule_penalties = get_penalties(nurse_schedule)
     schedule_shifts = get_shifts(nurse_schedule)
     month_info = get_month_info(nurse_schedule)
     workers_info = get_workers_info(nurse_schedule)
 
-    _, errors = score(schedule_shifts, month_info, workers_info, return_errors = true)
+    _, errors = score(schedule_shifts, month_info, workers_info, schedule_penalties, return_errors = true)
     return errors
 end
 

--- a/src/schedule.jl
+++ b/src/schedule.jl
@@ -17,7 +17,7 @@ mutable struct Schedule
 end
 
 function get_penalties(schedule)::Dict{String,Any}
-    weights = CONFIG["weightMap"]
+    weights = CONFIG["weight_map"]
     custom_priority = get(schedule.data, "penalty_priorities", nothing)
     penalties = Dict{String,Any}()
 

--- a/src/schedule.jl
+++ b/src/schedule.jl
@@ -13,6 +13,18 @@ mutable struct Schedule
     end
 end
 
+function get_penalties(schedule)::Dict{String,Any}
+    default_params = JSON.parsefile("config/default.json")["penalties"]
+    schedule_params = get(schedule.data, "solver_params", nothing)
+    if !isnothing(schedule_params)
+        for key in keys(default_params)
+            default_params[key] = get(schedule_params, key, default_params[key])
+        end
+    end
+
+    return default_params
+end
+
 function get_shifts(schedule::Schedule)::ScheduleShifts
     workers = collect(keys(schedule.data["shifts"]))
     shifts = collect(values(schedule.data["shifts"]))

--- a/src/schedule.jl
+++ b/src/schedule.jl
@@ -1,3 +1,6 @@
+using ..NurseSchedules:
+        CONFIG
+
 mutable struct Schedule
     data::Dict
 
@@ -14,15 +17,20 @@ mutable struct Schedule
 end
 
 function get_penalties(schedule)::Dict{String,Any}
-    default_params = JSON.parsefile("config/default.json")["penalties"]
-    schedule_params = get(schedule.data, "solver_params", nothing)
-    if !isnothing(schedule_params)
-        for key in keys(default_params)
-            default_params[key] = get(schedule_params, key, default_params[key])
-        end
+    weights = CONFIG["weightMap"]
+    custom_priority = get(schedule.data, "penalty_priorities", nothing)
+    penalties = Dict{String,Any}()
+
+    priority = if !isnothing(custom_priority)
+        custom_priority
+    else
+        CONFIG["penalties"]
     end
 
-    return default_params
+    for (key, pen) in zip(priority, weights)
+        penalties[key] = pen
+    end
+    return penalties
 end
 
 function get_shifts(schedule::Schedule)::ScheduleShifts

--- a/src/scoring.jl
+++ b/src/scoring.jl
@@ -33,10 +33,6 @@ using ..NurseSchedules:
     LONG_BREAK_SEQ,
     MAX_OVERTIME,
     MAX_UNDERTIME,
-    PEN_LACKING_NURSE,
-    PEN_LACKING_WORKER,
-    PEN_DISALLOWED_SHIFT_SEQ,
-    PEN_NO_LONG_BREAK,
     WORKTIME_BASE,
     WEEK_DAYS_NO,
     NUM_WORKING_DAYS,
@@ -52,17 +48,18 @@ using ..NurseSchedules:
 function score(
     schedule_shifts::ScheduleShifts,
     month_info::Dict{String,Any},
-    workers_info::Dict{String,Any};
-    return_errors::Bool = false,
+    workers_info::Dict{String,Any},
+    pen::Dict{String,Any};
+    return_errors::Bool = false
 )::ScoringResultOrPenalty
     workers, shifts = schedule_shifts
     score_res = ScoringResult((0, []))
 
-    score_res += ck_workers_presence(schedule_shifts, month_info, workers_info)
+    score_res += ck_workers_presence(schedule_shifts, month_info, workers_info, pen)
 
-    score_res += ck_workers_rights(workers, shifts)
+    score_res += ck_workers_rights(workers, shifts, pen)
 
-    score_res += ck_workers_worktime(workers, shifts, workers_info, month_info)
+    score_res += ck_workers_worktime(workers, shifts, workers_info, month_info,)
 
     if return_errors
         score_res
@@ -75,13 +72,14 @@ function ck_workers_presence(
     schedule_shifts::ScheduleShifts,
     month_info::Dict{String,Any},
     workers_info::Dict{String,Any},
+    pen::Dict{String,Any}
 )::ScoringResult
     workers, shifts = schedule_shifts
     score_res = ScoringResult((0, []))
     for day_no in axes(shifts, 2)
         day_shifts = shifts[:, day_no]
-        score_res += ck_workers_to_children(day_no, day_shifts, month_info)
-        score_res += ck_nurse_presence(day_no, workers, day_shifts, workers_info)
+        score_res += ck_workers_to_children(day_no, day_shifts, month_info, pen)
+        score_res += ck_nurse_presence(day_no, workers, day_shifts, workers_info, pen)
     end
     if score_res.penalty > 0
         @debug "Lacking workers total penalty: $(score_res.penalty)"
@@ -93,6 +91,7 @@ function ck_workers_to_children(
     day::Int,
     day_shifts::Vector{String},
     month_info::Dict{String,Any},
+    pen::Dict{String,Any}
 )::ScoringResult
     errors = Vector{Dict{String,Any}}()
 
@@ -115,7 +114,7 @@ function ck_workers_to_children(
     missing_wrk_night = (missing_wrk_night < 0) ? 0 : missing_wrk_night
 
     # penalty is charged only for workers lacking during daytime
-    penalty = missing_wrk_day * PEN_LACKING_WORKER
+    penalty = missing_wrk_day * pen["LACKING_WORKER"]
 
     if penalty > 0
         error_details = ""
@@ -148,7 +147,13 @@ function ck_workers_to_children(
     return ScoringResult((penalty, errors))
 end
 
-function ck_nurse_presence(day::Int, wrks, day_shifts, workers_info)::ScoringResult
+function ck_nurse_presence(
+    day::Int, 
+    wrks, 
+    day_shifts, 
+    workers_info::Dict{String,Any}, 
+    pen::Dict{String, Any}
+)::ScoringResult
     penalty = 0
     errors = Vector{Dict{String,Any}}()
     nrs_shifts = [
@@ -159,7 +164,7 @@ function ck_nurse_presence(day::Int, wrks, day_shifts, workers_info)::ScoringRes
     ]
     if isempty(SHIFTS_MORNING ∩ nrs_shifts)
         @debug "Lacking a nurse in the morning on day '$day'"
-        penalty += PEN_LACKING_NURSE
+        penalty += pen["LACKING_NURSE"]
         push!(
             errors,
             Dict(
@@ -171,7 +176,7 @@ function ck_nurse_presence(day::Int, wrks, day_shifts, workers_info)::ScoringRes
     end
     if isempty(SHIFTS_AFTERNOON ∩ nrs_shifts)
         @debug "Lacking a nurse in the afternoon on day '$day'"
-        penalty += PEN_LACKING_NURSE
+        penalty += pen["LACKING_NURSE"]
         push!(
             errors,
             Dict(
@@ -183,7 +188,7 @@ function ck_nurse_presence(day::Int, wrks, day_shifts, workers_info)::ScoringRes
     end
     if isempty(SHIFTS_NIGHT ∩ nrs_shifts)
         @debug "Lacking a nurse in the night on day '$day'"
-        penalty += PEN_LACKING_NURSE
+        penalty += pen["LACKING_NURSE"]
         push!(
             errors,
             Dict(
@@ -196,7 +201,11 @@ function ck_nurse_presence(day::Int, wrks, day_shifts, workers_info)::ScoringRes
     return ScoringResult((penalty, errors))
 end
 
-function ck_workers_rights(workers, shifts)::ScoringResult
+function ck_workers_rights(
+    workers, 
+    shifts, 
+    pen::Dict{String,Any}
+)::ScoringResult
     penalty = 0
     errors = Vector{Dict{String,Any}}()
     for worker_no in axes(shifts, 1)
@@ -212,7 +221,7 @@ function ck_workers_rights(workers, shifts)::ScoringResult
                shifts[worker_no, shift_no+1] in
                DISALLOWED_SHIFTS_SEQS[shifts[worker_no, shift_no]]
 
-                penalty += PEN_DISALLOWED_SHIFT_SEQ
+                penalty += pen["DISALLOWED_SHIFT_SEQ"]
                 @debug "The worker '$(workers[worker_no])' has a disallowed shift sequence " *
                        "on day '$(shift_no + 1)': " *
                        "$(shifts[worker_no, shift_no]) -> $(shifts[worker_no, shift_no + 1])"
@@ -243,7 +252,7 @@ function ck_workers_rights(workers, shifts)::ScoringResult
         if false in long_breaks
             for (week_no, value) in enumerate(long_breaks)
                 if value == false
-                    penalty += PEN_NO_LONG_BREAK
+                    penalty += pen["NO_LONG_BREAK"]
                     @debug "The worker '$(workers[worker_no])' does not have a long break in week: '$(week_no)'"
                     push!(
                         errors,
@@ -260,7 +269,12 @@ function ck_workers_rights(workers, shifts)::ScoringResult
     return ScoringResult((penalty, errors))
 end
 
-function ck_workers_worktime(workers, shifts, workers_info, month_info)::ScoringResult
+function ck_workers_worktime(
+    workers, 
+    shifts, 
+    workers_info::Dict{String,Any}, 
+    month_info::Dict{String,Any}
+)::ScoringResult
     penalty = 0
     errors = Vector{Dict{String,Any}}()
     workers_worktime = Dict{String,Int}()


### PR DESCRIPTION
Na razie to draft, bo przydałoby się przetestować, ale myślę, że jest oczekiwana funkcjonalność.

- Przeniosłem kary za ograniczenia i domyślne priorytety do pliku `config/default.json`, 
- Funkcja score przyjmuje teraz słownik kar zamiast brać z `constants.jl`,
- Jeśli _schedule_ zawiera tablicę _penalty_priorities_ to pobiera z niej priorytety, w przeciwnym razie bierze domyślne,
-  Dodałem walidację _schedule_ względem tych priorytetów, jeśli lista pliku nie jest poprawna rzuca error.