### PR TITLE
Task 255 - Dynamic long breaks

### DIFF
--- a/src/constants.jl
+++ b/src/constants.jl
@@ -25,25 +25,15 @@ MutationRecipe = @NamedTuple{
     optional_info::StringOrNothing,
 }
 
-# shift types
-const R = "R"    # morning (7-15)
-const P = "P"    # afternoon (15-19)
-const D = "D"    # daytime == R + P (7-19)
-const N = "N"    # night (19-7)
-const DN = "DN"  # day == D + N (7-7)
-const PN = "PN"  # afternoon-night == P + N (15-7)
-const W = "W"    # day free
-const U = "U"    # vacation
-const L4 = "L4"  # sick leave
-
-# decrease required worktime
-const SHIFTS_EXEMPT = [U, L4]
+# day free dict
+const W_DICT = Dict("from" => 7,
+                    "to" => 15,
+                    "is_working_shift" => false)
 
 const REQ_CHLDN_PER_NRS_DAY = 3
 const REQ_CHLDN_PER_NRS_NIGHT = 5
 
 # there has to be such a seq each week
-const LONG_BREAK_SEQ = (([U, L4, W], [N, U, L4, W]), ([R, P, D], [U, L4, W]))
 const LONG_BREAK_HOURS = 35
 
 # under and overtime pen is equal to hours from <0, MAX_OVERTIME>

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -44,6 +44,7 @@ const REQ_CHLDN_PER_NRS_NIGHT = 5
 
 # there has to be such a seq each week
 const LONG_BREAK_SEQ = (([U, L4, W], [N, U, L4, W]), ([R, P, D], [U, L4, W]))
+const LONG_BREAK_HOURS = 35
 
 # under and overtime pen is equal to hours from <0, MAX_OVERTIME>
 const MAX_OVERTIME = 10 # scaled by the number of weeks

--- a/src/neighborhood.jl
+++ b/src/neighborhood.jl
@@ -9,8 +9,7 @@ using ..NurseSchedules:
     Schedule, 
     Shifts, 
     get_changeable_shifts,
-    get_shifts, 
-    W,
+    get_shifts,
     Mutation, 
     MutationRecipe
     

--- a/src/neighborhood.jl
+++ b/src/neighborhood.jl
@@ -8,7 +8,7 @@ export Neighborhood, get_max_nbhd_size, n_split_nbhd, perform_random_jumps!
 using ..NurseSchedules:
     Schedule, 
     Shifts, 
-    get_changeable_shifts_keys,
+    get_changeable_shifts,
     get_shifts, 
     W,
     Mutation, 
@@ -130,7 +130,7 @@ function get_nbhd(shifts::Shifts, schedule::Schedule)::Vector{MutationRecipe}
     for person_shift in CartesianIndices(shifts)
         mutated_schedules = if shifts[person_shift] == W
             with_shift_addtion(shifts, person_shift, schedule)
-        elseif shifts[person_shift] in get_changeable_shifts_keys(schedule)
+        elseif shifts[person_shift] in keys(get_changeable_shifts(schedule))
             vcat(
                 with_shift_deletion(shifts, person_shift),
                 with_shift_swap(shifts, person_shift, schedule),
@@ -150,7 +150,7 @@ function with_shift_addtion(shifts::Shifts, p_shift, schedule::Schedule)::Vector
             day = p_shift[2],
             wrk_no = p_shift[1],
             optional_info = allowed_shift,
-        )) for allowed_shift in get_changeable_shifts_keys(schedule)
+        )) for allowed_shift in keys(get_changeable_shifts(schedule))
     ]
 end
 
@@ -174,7 +174,7 @@ function with_shift_swap(shifts::Shifts, p_shift, schedule::Schedule)::Vector{Mu
         for
         o_person in axes(shifts, 1) if
         p_shift[1] < o_person &&
-        shifts[o_person, p_shift[2]] in get_changeable_shifts_keys(schedule) &&
+        shifts[o_person, p_shift[2]] in keys(get_changeable_shifts(schedule)) &&
         shifts[o_person, p_shift[2]] != shifts[p_shift]
     ]
 end

--- a/src/scoring.jl
+++ b/src/scoring.jl
@@ -15,6 +15,7 @@ using ..NurseSchedules:
     get_shift_options,
     get_disallowed_sequences,
     get_changeable_shifts,
+    get_exempted_shifts,
     get_earliest_shift_begin,
     get_latest_shift_end,
     get_day,
@@ -23,10 +24,8 @@ using ..NurseSchedules:
     ScheduleShifts,
     Shifts,
     Workers,
-    SHIFTS_EXEMPT,
     REQ_CHLDN_PER_NRS_DAY,
     REQ_CHLDN_PER_NRS_NIGHT,
-    LONG_BREAK_SEQ,
     LONG_BREAK_HOURS,
     MAX_OVERTIME,
     MAX_UNDERTIME,
@@ -327,7 +326,7 @@ function ck_workers_worktime(
 
         while !isempty(worker_shifts)
             week_exempted_days_no =
-                count(s -> (s in SHIFTS_EXEMPT), splice!(worker_shifts, 1:WEEK_DAYS_NO))
+                count(s -> (s in keys(get_exempted_shifts(schedule))), splice!(worker_shifts, 1:WEEK_DAYS_NO))
             exempted_days_no += if week_exempted_days_no > NUM_WORKING_DAYS
                 NUM_WORKING_DAYS
             else

--- a/src/scoring.jl
+++ b/src/scoring.jl
@@ -14,6 +14,8 @@ using ..NurseSchedules:
     get_month_info,
     get_shift_options,
     get_disallowed_sequences,
+    get_earliest_shift_begin,
+    get_latest_shift_end,
     get_day,
     ScoringResult,
     ScoringResultOrPenalty,
@@ -24,6 +26,7 @@ using ..NurseSchedules:
     REQ_CHLDN_PER_NRS_DAY,
     REQ_CHLDN_PER_NRS_NIGHT,
     LONG_BREAK_SEQ,
+    LONG_BREAK_HOURS,
     MAX_OVERTIME,
     MAX_UNDERTIME,
     WORKTIME_BASE,
@@ -268,6 +271,32 @@ function ck_workers_rights(
             end
         end
     end
+    return ScoringResult((penalty, errors)) + ck_workers_long_breaks(schedule_shitfs, schedule)
+end
+
+function ck_workers_long_breaks(
+    schedule_shifts::Shifts,
+    schedule::Schedule
+)::ScoringResult
+    penalty = 0
+    errors = Vector{Dict{String,Any}}()
+    workers, shifts = schedule_shitfs
+    penalties = get_penalties(schedule)
+    weeks_no = ceil(Int, size(shifts, 2) / WEEK_DAYS_NO)
+    required_break_time = LONG_BREAK_HOURS - (24 - get_latest_shift_end(schedule)) - get_earliest_shift_begin(schedule)
+
+    for week in 1:weeks_no
+        long_breaks = fill(false, size(workers, 1))
+        first_week_day = (week-1) * WEEK_DAYS_NO
+        last_week_day = week * WEEK_DAYS_NO - 1
+        for worker_no in axes(shifts, 1)
+            break_time = 0
+            for shifts_no in first_week_day:last_week_day
+
+            end
+        end
+    end
+
     return ScoringResult((penalty, errors))
 end
 

--- a/src/validation.jl
+++ b/src/validation.jl
@@ -98,6 +98,7 @@ function contains_all_required_shifts(data::Dict)
     used_shifts = Set(Iterators.flatten([
         shift for shift in values(data["shifts"])
     ]))
+    push!(used_shifts, "W")
     if intersect(used_shifts, available_shifts) == used_shifts
         "OK"
     else

--- a/test/engine_tests.jl
+++ b/test/engine_tests.jl
@@ -26,18 +26,8 @@ function solve(file::String)
 end
 
 function get_errors_sets(file::String)::Tuple{Set, Set}
-    # Suppress scoring debug
-    debug = nothing
-    if "JULIA_DEBUG" in keys(ENV)
-        debug = ENV["JULIA_DEBUG"]
-        delete!(ENV, "JULIA_DEBUG")
-    end
     new_errors = get_errors(file)
     old_errors = OldNurseSchedules.get_errors(file)
-    if !isnothing(debug)
-        ENV["JULIA_DEBUG"] = debug
-    end
-
     old_errors = Set(vcat(
         # Pass non AON errors
         filter(x -> x["code"] != "AON", old_errors),
@@ -65,10 +55,10 @@ function check_single_type_errors(code::String, file::String)
     if old == new
         true
     else
-        @debug "Different errors for type and file: " code file 
-        @debug "Old \\ New " setdiff(old, new)
-        @debug "New \\ Old " setdiff(new, old)
-        @debug ""
+        @info "Different errors for type and file: " code file 
+        @info "Old \\ New " setdiff(old, new)
+        @info "New \\ Old " setdiff(new, old)
+        @info ""
         false
     end
 end
@@ -76,10 +66,10 @@ end
 ShiftSequence = Dict{String, Array{String, 1}}
 function compare_dss(old::ShiftSequence, new::ShiftSequence)
     for (key, table) in new
-        if table != [] && sort(old[key]) != sort(table)
-            @debug "Different sequences for key: " key
-            @debug "Old sequence " old[key]
-            @debug "New sequence " table
+        if !isempty(table) && sort(old[key]) != sort(table)
+            @info "Different sequences for key: " key
+            @info "Old sequence " old[key]
+            @info "New sequence " table
             return false
         end
     end

--- a/test/engine_tests.jl
+++ b/test/engine_tests.jl
@@ -8,7 +8,9 @@ using Test
 using .NurseSchedules:
     Schedule,
     get_disallowed_sequences,
-    get_next_day_distance
+    get_next_day_distance,
+    get_earliest_shift_begin,
+    get_latest_shift_end
 
 function repair!(schedule::Schedule)
     fix = repair_schedule(schedule.data)
@@ -112,4 +114,10 @@ end
     @test get_next_day_distance(y, z) == -4
     @test get_next_day_distance(z, x) == 28
     @test get_next_day_distance(z, y) == 36
+end
+
+@testset "Schedule tests" begin
+    schedule = Schedule("schedules/schedule_2016_august_medium.json")
+    @test get_earliest_shift_begin(schedule) == 7
+    @test get_latest_shift_end(schedule) == 31
 end


### PR DESCRIPTION
Uznałem, że liczenie godzin będzie może lepszym rozwiązaniem, bo wyliczanie sekwencji bez nadmiarowych nie wyglądało mi ładnie na kartce, plus nie zawsze sekwencja musiałaby być dwuelementowa.

Aktualna wersja scoringu, liczy po prostu w każdym tygodniu bloki przerw, zaczynając z 24 - koniec najpóźniejszej zmiany (jeśli zmiana przechodzi przez północ, to dodajemy 24h). Jeśli napotka zmianę wolną, dodaje 24h, w pozostałych dodaje czas do zmiany i sprawdza czy pasuje.

Wrzucam jako drafta, bo przechodzi 3/5 testów na ten moment