### PR TITLE
TASK-337 Evaluate only chosen constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ The process of automated fixing a schedule can be controlled in terms of removin
     "DSS"
 ]
 ```
-All the shift codes from the table below must be listed, otherwise the schedule will not be accepted.
+If priority code is not listed, the solver will set weight as 0 and will not return any errors related to that code.
 
 | Penalty                         | Code | default weight |
 |---------------------------------|------|:--------------:|

--- a/schedules/schedule_2016_august_custom.json
+++ b/schedules/schedule_2016_august_custom.json
@@ -1,0 +1,176 @@
+{
+    "schedule_info":{
+        "UUID": "",
+        "month_number": 8,
+        "year": 2016
+    },
+    "penalty_priorities" : [
+        "LLB",
+        "DSS",
+        "WND"
+    ],
+    "month_info": {
+        "day_begin" : 7,
+        "night_begin" : 19,
+        "frozen_shifts": [],
+        "extra_workers": [
+            4, 4, 4, 4, 4, 4, 4
+        ],
+        "children_number": [
+            24, 21, 21, 21, 21, 21, 21
+        ],
+        "holidays": [
+            7
+        ]
+    },
+    "shift_types" : {
+        "R" : {
+            "from" : 7,
+            "to" : 15,
+            "is_working_shift" : true
+        },
+        "P" : {
+            "from" : 15,
+            "to" : 19,
+            "is_working_shift" : true
+        },
+        "D" : {
+            "from" : 7,
+            "to" : 19,
+            "is_working_shift" : true
+        },
+        "N" : {
+            "from" : 19,
+            "to" : 7,
+            "is_working_shift" : true
+        },
+        "DN" : {
+            "from" : 7,
+            "to" : 7,
+            "is_working_shift" : true
+        },
+        "PN" : {
+            "from" : 15,
+            "to" : 7,
+            "is_working_shift" : true
+        },
+        "W" : {
+            "from" : 7,
+            "to" : 15,
+            "is_working_shift" : false
+        },
+        "U" : {
+            "from" : 7,
+            "to" : 15,
+            "is_working_shift" : false
+        },
+        "L4" : {
+            "from" : 7,
+            "to" : 15,
+            "is_working_shift" : false
+        }
+    },
+    "employee_info": {
+        "time": {
+            "nurse_1":  1.0,
+            "nurse_2":  1.0,
+            "nurse_3":  1.0,
+            "nurse_4":  1.0,
+            "nurse_5":  0.5,
+            "nurse_6":  0.5,
+            "nurse_7":  0.5,
+            "nurse_8":  1.0,
+            "nurse_9":  1.0,
+            "babysitter_1": 1.0,
+            "babysitter_2": 0.5,
+            "babysitter_3": 0.5,
+            "babysitter_4": 1.0,
+            "babysitter_5": 1.0,
+            "babysitter_6": 1.0,
+            "babysitter_7": 0.5,
+            "babysitter_8": 1.0,
+            "babysitter_9": 1.0,
+            "babysitter_10": 0.5
+        },
+        "type": {
+            "nurse_1":  "NURSE",
+            "nurse_2":  "NURSE",
+            "nurse_3":  "NURSE",
+            "nurse_4":  "NURSE",
+            "nurse_5":  "NURSE",
+            "nurse_6":  "NURSE",
+            "nurse_7":  "NURSE",
+            "nurse_8":  "NURSE",
+            "nurse_9":  "NURSE",
+            "babysitter_1": "OTHER",
+            "babysitter_2": "OTHER",
+            "babysitter_3": "OTHER",
+            "babysitter_4": "OTHER",
+            "babysitter_5": "OTHER",
+            "babysitter_6": "OTHER",
+            "babysitter_7": "OTHER",
+            "babysitter_8": "OTHER",
+            "babysitter_9": "OTHER",
+            "babysitter_10": "OTHER"
+        }
+    },
+    "shifts": {
+        "nurse_1": [
+            "R", "R", "W", "W", "D", "DN", "W"
+        ],
+        "nurse_2": [
+            "N", "W", "N", "W", "W", "W", "DN"
+        ],
+        "nurse_3": [
+            "DN", "W", "DN", "N", "W", "DN", "N"
+        ],
+        "nurse_4": [
+            "N", "W", "D", "D", "N", "W", "D"
+        ],
+        "nurse_5": [
+            "W", "W", "W", "W", "W", "W", "W"
+        ],
+        "nurse_6": [
+            "U", "U", "U", "U", "U", "U", "U"
+        ],
+        "nurse_7": [
+            "U", "U", "U", "U", "U", "U", "U"
+        ],
+        "nurse_8": [
+            "D", "N", "W", "D", "R", "W", "D"
+        ],
+        "nurse_9": [
+            "W", "DN", "W", "W", "DN", "W", "W"
+        ],
+        "babysitter_1": [
+            "U", "U", "U", "U", "U", "U", "U"
+        ],
+        "babysitter_2": [
+            "L4", "L4", "L4", "L4", "L4", "L4", "L4"
+        ],
+        "babysitter_3": [
+            "U", "U", "U", "U", "U", "U", "U"
+        ],
+        "babysitter_4": [
+            "D", "N", "W", "D", "N", "W", "DN"
+        ],
+        "babysitter_5": [
+            "D", "P", "N", "N", "W", "W", "W"
+        ],
+        "babysitter_6": [
+            "W", "N", "N", "N", "N", "N", "W"
+        ],
+        "babysitter_7": [
+            "W", "D", "D", "W", "D", "DN", "W"
+        ],
+        "babysitter_8": [
+            "L4", "L4", "L4", "L4", "L4", "L4", "L4"
+        ],
+        "babysitter_9": [
+            "N", "W", "D", "N", "P", "W", "W"
+        ],
+        "babysitter_10": [
+            "W", "D", "W", "D", "W", "D", "W"
+        ]
+    }
+}

--- a/src/schedule.jl
+++ b/src/schedule.jl
@@ -28,18 +28,25 @@ end
 
 function get_penalties(schedule)::Dict{String,Any}
     weights = CONFIG["weight_map"]
+    default_priority = CONFIG["penalties"]
     custom_priority = get(schedule.data, "penalty_priorities", nothing)
     penalties = Dict{String,Any}()
 
-    priority = if !isnothing(custom_priority)
-        custom_priority
-    else
-        CONFIG["penalties"]
+    if isnothing(custom_priority)
+        return Dict(
+            key => pen
+            for (key, pen) in zip(default_priority, weights)
+        )
     end
 
-    for (key, pen) in zip(priority, weights)
-        penalties[key] = pen
+    for key in default_priority
+        if key in custom_priority
+            penalties[key] = weights[findall(x -> x == key, custom_priority)[1]]
+        else
+            penalties[key] = 0
+        end
     end
+
     return penalties
 end
 

--- a/src/server.jl
+++ b/src/server.jl
@@ -29,7 +29,7 @@ route("/fix_schedule", method = POST) do
         flush_logs()
         schedule.data |> json
     catch err
-        @error "Unexpected error at fix schedule : " err.msg
+        @error "Unexpected error at fix schedule : " sprint(showerror, err)
         @error "Schedule ID: " request_name
         @error "Backtrace: " catch_backtrace() 
         flush_logs()
@@ -49,7 +49,7 @@ route("/schedule_errors", method = POST) do
         flush_logs()
         errors |> json
     catch err
-        @error "Unexpected error at schedule errors : " err.msg
+        @error "Unexpected error at schedule errors : " sprint(showerror, err)
         @error "Schedule ID: " request_name
         @error "Backtrace: " catch_backtrace()
         flush_logs()

--- a/src/server.jl
+++ b/src/server.jl
@@ -30,7 +30,7 @@ route("/fix_schedule", method = POST) do
         schedule.data |> json
     catch err
         @error "Unexpected error at fix schedule : " err.msg
-        @error "Schedule ID: " log_id
+        @error "Schedule ID: " request_name
         @error "Backtrace: " catch_backtrace() 
         flush_logs()
         Dict() |> json
@@ -50,7 +50,7 @@ route("/schedule_errors", method = POST) do
         errors |> json
     catch err
         @error "Unexpected error at schedule errors : " err.msg
-        @error "Schedule ID: " log_id
+        @error "Schedule ID: " request_name
         @error "Backtrace: " catch_backtrace()
         flush_logs()
         Dict() |> json

--- a/src/validation.jl
+++ b/src/validation.jl
@@ -59,19 +59,14 @@ function contains_all_or_none_penalties(data::Dict)
     schedule_priority = get(data, "penalty_priorities", nothing)
 
     if !isnothing(schedule_priority)
-        default_priority = JSON.parsefile("config/default/priorities.json")["penalties"]
-        sort!(schedule_priority)
-        sort!(default_priority)
-        if length(default_priority) != length(schedule_priority)
-            "wrong priorities length, received '$(length(schedule_priority))', excpected '$(length(default_priority))'"
-        elseif !isequal(default_priority, schedule_priority)
-            "priorities list doesn't contain all entries"
-        else
-            "OK"
+        accepted_list = JSON.parsefile("config/default/priorities.json")["penalties"]
+        for member in schedule_priority
+            if !(member in accepted_list)
+               return "NOT OK" 
+            end
         end
-    else
-        "OK"
     end
+    return "OK"
 end
 
 function day_night_assumption(data::Dict)

--- a/test/engine_tests.jl
+++ b/test/engine_tests.jl
@@ -130,3 +130,13 @@ end
     @test get_earliest_shift_begin(schedule) == 7
     @test get_latest_shift_end(schedule) == 31
 end
+
+@testset "Custom penalties tests" begin
+    applied_errors = ["WNN", "WND", "LLB", "DSS"]
+    schedule = "schedules/schedule_2016_august_custom.json"
+    new_errors = get_errors(schedule)
+    @test isempty(filter(x -> x["code"] == "AON", new_errors))
+    for err_type in applied_errors
+        @test check_single_type_errors(err_type, schedule)
+    end
+end


### PR DESCRIPTION
Od teraz solver przyjmuje w _penalty_priorites_ dowolny podzbiór wszystkich kluczy, ustala wagi od największej według kolejności, a dla kluczy niewymienionych ustawia wagę 0. Scoring ignoruje wszystkie ewaluacje z wagami zerowymi, zwracając pustą listę błędów.