### PR TITLE
TASK-367 Day segments fix

### DIFF
--- a/src/constants.jl
+++ b/src/constants.jl
@@ -44,6 +44,8 @@ const CONFIG = JSON.parsefile("config/default/priorities.json")
 const SHIFTS = JSON.parsefile("config/default/shifts.json")
 const DAY_BEGIN = 6
 const NIGHT_BEGIN = 22
+ 
+const PERIOD_BEGIN = 7
 
 # weekly worktime
 const WORKTIME_BASE = 40

--- a/src/schedule.jl
+++ b/src/schedule.jl
@@ -5,6 +5,7 @@ using ..NurseSchedules:
         CONFIG,
         SHIFTS,
         W_DICT,
+        PERIOD_BEGIN,
         get_next_day_distance,
         get_rest_length        
 
@@ -124,6 +125,13 @@ function update_shifts!(schedule::Schedule, shifts)
     for worker_no in axes(shifts, 1)
         schedule.data["shifts"][workers[worker_no]] = shifts[worker_no, :]
     end
+end
+
+function get_period_range()::Vector{Int}
+    vcat(
+        collect(PERIOD_BEGIN:24),
+        collect(1:(PERIOD_BEGIN - 1))
+    )
 end
 
 get_shifts_distance(shifts_1::Shifts, shifts_2::Shifts)::Int =

--- a/src/scoring.jl
+++ b/src/scoring.jl
@@ -19,6 +19,7 @@ using ..NurseSchedules:
     get_earliest_shift_begin,
     get_latest_shift_end,
     get_day,
+    get_period_range,
     ScoringResult,
     ScoringResultOrPenalty,
     ScheduleShifts,
@@ -111,7 +112,7 @@ function ck_workers_to_children(
     act_wrk_day = req_wrk_day
     act_wrk_night = req_wrk_night
 
-    for hour = 1:24
+    for hour in get_period_range()
         current_workers = count([
             within(hour, shift_info[shift])
             for shift in day_shifts    
@@ -232,7 +233,7 @@ function ck_nurse_presence(day::Int, wrks, day_shifts, schedule::Schedule)::Scor
     empty_segments = []
     segment_begin = nothing
 
-    for hour = 1:24
+    for hour in get_period_range()
         if hours_pop[hour] == 0
             penalty += penalties[string(Constraints.PEN_LACKING_NURSE)]
             if isnothing(segment_begin)


### PR DESCRIPTION
Now scoring evaluates hours using [PERIOD_BEGIN ... 24, 1 ... PERIOD_BEGIN-1] instead of [1...24].