### PR TITLE
TASK-367 Fix time segments evaluation

### DIFF
--- a/src/scoring.jl
+++ b/src/scoring.jl
@@ -26,6 +26,7 @@ using ..NurseSchedules:
     Shifts,
     Workers,
     REQ_CHLDN_PER_NRS_DAY,
+    PERIOD_BEGIN,
     REQ_CHLDN_PER_NRS_NIGHT,
     LONG_BREAK_HOURS,
     MAX_OVERTIME,
@@ -156,7 +157,7 @@ function ck_workers_to_children(
             popfirst!(day_segments)
             push!(day_segments, (day_segments_begin, first_block[2]))
         else
-            push!(day_segments, (day_segments_begin, 24))
+            push!(day_segments, (day_segments_begin, PERIOD_BEGIN))
         end
     elseif !isnothing(night_segments_begin)
         first_block = get(night_segments, 1, (-1, -1))
@@ -164,7 +165,7 @@ function ck_workers_to_children(
             popfirst!(night_segments)
             push!(night_segments, (night_segments_begin, first_block[2]))
         else
-            push!(night_segments, (night_segments_begin, 24))
+            push!(night_segments, (night_segments_begin, PERIOD_BEGIN))
         end
     end
 
@@ -247,7 +248,7 @@ function ck_nurse_presence(day::Int, wrks, day_shifts, schedule::Schedule)::Scor
 
     # Close last
     if !isnothing(segment_begin)
-        push!(empty_segments, (segment_begin, 24))
+        push!(empty_segments, (segment_begin, PERIOD_BEGIN))
     end
 
     if empty_segments != []


### PR DESCRIPTION
Fun fact, po zmianie początku doby z 24 na zmienną __PERIOD_BEGIN__ zapomniałem tego zmienić w scoringu, stąd te dziwne przedziały xD