### PR TITLE
TASK-453 custom norm substractions

### DIFF
--- a/src/scoring.jl
+++ b/src/scoring.jl
@@ -467,7 +467,9 @@ function ck_workers_worktime(
 
         shift_exemption = 0
         for shift in worker_shifts
-            shift_exemption += get_shift_norm_sub(shift_info[shift])
+            if shift != "W"
+                shift_exemption += get_shift_norm_sub(shift_info[shift])
+            end
         end
 
         req_worktime = (num_days - holidays_no) * hours_per_day - shift_exemption

--- a/src/shifts.jl
+++ b/src/shifts.jl
@@ -12,6 +12,8 @@ ShiftType = Dict{String, Any}
     Returns number of hours to be substracted from the norm
     Args:
         shift::ShiftType    - dictionary containing shift description
+    Note:
+        W shift is not working shift, so this function will return 8 instead of 0
 """
 function get_shift_norm_sub(shift::ShiftType)::Int
     if shift["is_working_shift"]

--- a/src/shifts.jl
+++ b/src/shifts.jl
@@ -6,6 +6,21 @@
 
 ShiftType = Dict{String, Any}
 
+
+
+"""
+    Returns number of hours to be substracted from the norm
+    Args:
+        shift::ShiftType    - dictionary containing shift description
+"""
+function get_shift_norm_sub(shift::ShiftType)::Int
+    if shift["is_working_shift"]
+        0
+    else
+        get(shift, "normSubstraction", 8)
+    end
+end
+
 """
     Computes wheter an hour is inside the shift
     Args:

--- a/test/data/example_shift.json
+++ b/test/data/example_shift.json
@@ -1,0 +1,8 @@
+{
+    "code": "test",
+    "name": "test",
+    "from": 1,
+    "to": 2,
+    "is_working_shift": true,
+    "normSubstraction": 15
+}

--- a/test/engine_tests.jl
+++ b/test/engine_tests.jl
@@ -5,13 +5,15 @@ include("old_engine/NurseScheduling.jl")
 include("../src/repair_schedule.jl")
 
 using Test
+using JSON
 using .NurseSchedules:
     Schedule,
     get_disallowed_sequences,
     get_next_day_distance,
     get_earliest_shift_begin,
     get_latest_shift_end,
-    sum_segments
+    sum_segments,
+    get_shift_norm_sub
 
 function repair!(schedule::Schedule)
     fix = repair_schedule(schedule.data)
@@ -151,5 +153,14 @@ end
         @test sum_segments(segments) == 4
         push!(segments, (22, 2))
         @test sum_segments(segments) == 8
+    end
+
+    open("test/data/example_shift.json", "r") do io
+        shift = JSON.parse(io)
+        @test get_shift_norm_sub(shift) == 0
+        shift["is_working_shift"] = false
+        @test get_shift_norm_sub(shift) == 15
+        delete!(shift, "normSubstraction")
+        @test get_shift_norm_sub(shift) == 8
     end
 end


### PR DESCRIPTION
Teraz silnik zamiast liczyć jakieś dni zwolnione, liczy bazę godzin tzn. (__num_days__ - __holidays_no__) * __hours_per_day__, po czym odejmuję od niej sumę zwolnionych (?) godzin ze wszystkich zmian.

Liczba godzin zwolnionych to 0 dla zmiany pracującej, 8 domyślnie dla niepracującej, lub wartość pola `normSubstraction` jeśli takie istnieje